### PR TITLE
Add missing `=` sign to `maintainer` label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.5.3
 
-LABEL maintainer "https://github.com/pielco11"
+LABEL maintainer="https://github.com/pielco11"
 LABEL malice.plugin.repository = "https://github.com/secrary/SSMA.git"
 LABEL malice.plugin.category="av"
 LABEL malice.plugin.mime="*"


### PR DESCRIPTION
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
